### PR TITLE
fixed a bug in the calculation of the month

### DIFF
--- a/Resources/ui/ScrollableView.js
+++ b/Resources/ui/ScrollableView.js
@@ -16,6 +16,7 @@ module.exports = function () {
 	
 	function addCalendar(month_d) {
 		var date = new Date(now);
+		date.setDate(1); // 月の計算用のため1日でセット
 		date.setMonth(date.getMonth() + month_d);
 		// load EventList View
 		var date = g.getDate(date);


### PR DESCRIPTION
1月31日にアプリを操作し、翌月を表示させるためにスワイプしたところ、3月が表示されてしまいました。
その後どのように操作しても2月が表示されることはなく、加えて4月や6月など、31日のない月が全て表示されませんでした。

これは表示するカレンダーの月を現在日付を元に計算していたため、JavaScriptのDateの仕様により、1月31日にsetMonthメソッドで1ヶ月を足すと、3月3日になってしまうことに起因すると思われます。

計算を行っている箇所では日付は特に用いていなかったため、計算で使用する日付を1日にセットして計算させるように修正しました。
